### PR TITLE
Remove prints of non-existing members

### DIFF
--- a/kernels/geometry/pointi.h
+++ b/kernels/geometry/pointi.h
@@ -212,7 +212,7 @@ namespace embree
     /*! output operator */
     friend __forceinline embree_ostream operator<<(embree_ostream cout, const PointMi& line)
     {
-      return cout << "Line" << M << "i {" << line.v0 << ", " << line.geomID() << ", " << line.primID() << "}";
+      return cout << "Line" << M << "i {" << line.geomID() << ", " << line.primID() << "}";
     }
 
    public:

--- a/kernels/subdiv/bezier_curve.h
+++ b/kernels/subdiv/bezier_curve.h
@@ -135,7 +135,7 @@ namespace embree
       }
       
       friend embree_ostream operator<<(embree_ostream cout, const QuadraticBezierCurve& a) {
-        return cout << "QuadraticBezierCurve ( (" << a.u.lower << ", " << a.u.upper << "), " << a.v0 << ", " << a.v1 << ", " << a.v2 << ")";
+        return cout << "QuadraticBezierCurve (" << a.v0 << ", " << a.v1 << ", " << a.v2 << ")";
       }
     };
   


### PR DESCRIPTION
With Clang 19.0.0 on Ubuntu 24.04, my build was broken because of these prints. The members `QuadraticBezierCurve::u` and `PointMi::v0` do not exist.
I don't know why it wasn't triggered before, maybe these functions were not instantiated before.

Initially reported by @ziyi-zhang.